### PR TITLE
exoALMA feature update and fixes

### DIFF
--- a/CO_layers/measure_height.py
+++ b/CO_layers/measure_height.py
@@ -248,7 +248,7 @@ class Surface:
         iv_min = nv
         iv_max = 0
         for i in range(self.iv_min,self.iv_max):
-            if np.max(image[i,:,:]) > 10*std:
+            if np.max(image[i,:,:]) > 15*std:
                 iv_min = np.minimum(iv_min,i)
                 iv_max = np.maximum(iv_max,i)
 
@@ -256,8 +256,6 @@ class Surface:
 
         iv1 = int(iv_syst-dv)
         iv2 = int(iv_syst+dv)
-
-        print(iv_min, iv_max, iv1, iv2)
 
         plt.figure(num+1)
         plt.plot(self.cube.velocity[[iv1,iv2]], profile[[iv1,iv2]], "o")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CO_layers
 
-CO_layers  is a python package that infer the geometry and velocity of the emitting moleclar layers of a protoplanetary disk
+CO_layers  is a python package that infer the geometry and velocity of the emitting molecular layers of a protoplanetary disk
 
 
 ## Installation:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 astropy
 scipy
 matplotlib
+alive-progress


### PR DESCRIPTION
This pull request covers several feature additions and bug fixes

- exoALMA convention: option to exclude inner radii equal to the beam size
- docstring update for new parameters, missing documentation, typo fixes and deprecated options
- plot parameter now turns on or off automatic plotting of plot_channels() and plot_surfaces()
- removed all deprecated or unused importations
- added alive-progress to requirements.txt
- fixed a few typos
- no more $ in the flux density plot axis
- removed several unused variables
- exoALMA convention: option to manually set the radial width of the velocity bins for rotation curves (v_bin_width)
- exoALMA convention: rotation curve can be saved as a .txt file
- fixed units of stellar mass from kgs to Msun in docs
- added save option to write the plots produced with plot_surfaces and plot_channels to pdf at print quality
- power law and stellar mass printing is now rounded to 5 decimal places at maximum
- bugfix: corrected tapered power law plotting
- star is now represented as a yellow star on plots. size is unchanged
- code now follows standard line length conventions, although should be updated to PEP-8 (79 characters) in the future
- bugfix: r_taper and q_taper were flipped in the tapered power law function
- bugfix: fixed the bounds for the tapered power law, thus preventing it from returning a flat function
- measure_height2.py: remove unused and deprecated importations
- measure_height2.py: added a plot parameter with the same behaviour as in measure_height.py
- measure_height2.py: added a try/except statement around back surface plotting routine, in the case no points are detected
- general python conventions and code clean up