### PR TITLE
bugfix in _ln_like function

### DIFF
--- a/dynamite/measure_height.py
+++ b/dynamite/measure_height.py
@@ -1436,7 +1436,7 @@ class Surface:
         v = self.v[scales,:,:].ravel().compressed()
 
         #using 1/snr as the error on the velocity
-        v_error = 1/(np.mean(self.snr[scales,:,:,:],axis=2).ravel()[np.invert(self.r[scales,:,:].mask.ravel())])
+        v_error = 1/(np.mean(self.snr[scales,:,:,:],axis=-1).ravel()[np.invert(self.r[scales,:,:].mask.ravel())])
 
         # chi2
         chi2 = np.sum(((v - v_model)**2 / v_error**2) + np.log(2*np.pi*v_error**2))


### PR DESCRIPTION
Bugfix: It seems like the indexing on `self.snr` inside `_ln_like` method was not updated when scales were added. 

This caused any initialisation of `Surface` with `dpc` given to raise an `IndexError`.

Changed index appropriately to resolve issue, very similar to [#0dd713f](https://github.com/cpinte/dynamite/commit/0dd713f5fa436696b4ddc873cbf2699b7ea1df6f). 